### PR TITLE
Deploy : 와랩 서버 배포를 위한 페이지 설정

### DIFF
--- a/src/layouts/dashboard/layout.tsx
+++ b/src/layouts/dashboard/layout.tsx
@@ -53,6 +53,7 @@ export default function DashboardLayout({ children }: Props) {
 
         <Box
           sx={{
+            
             minHeight: 1,
             display: 'flex',
             flexDirection: { xs: 'column', lg: 'row' },

--- a/src/layouts/dashboard/main.tsx
+++ b/src/layouts/dashboard/main.tsx
@@ -29,7 +29,6 @@ export default function Main({ children, sx, ...other }: BoxProps) {
           display: 'flex',
           flexDirection: 'column',
           pt: `${HEADER.H_MOBILE + 24}px`,
-
           pb: 10,
           ...(lgUp && {
             pt: `${HEADER.H_MOBILE * 2 + 40}px`,

--- a/src/pages/auth/jwt/login.tsx
+++ b/src/pages/auth/jwt/login.tsx
@@ -11,7 +11,7 @@ export default function LoginPage() {
         <title>SW 마일리지 학생 시스템 로그인</title>
       </Helmet>
 
-      <JwtLoginView />
+    <JwtLoginView />
     </>
   );
 }

--- a/src/routes/paths.ts
+++ b/src/routes/paths.ts
@@ -1,5 +1,5 @@
 // ----------------------------------------------------------------------
-const DOMAIN = process.env.REACT_APP_HOST_BASE_DOMAIN;
+export const DOMAIN = process.env.REACT_APP_HOST_BASE_DOMAIN;
 
 const ROOTS = {
   AUTH: `${DOMAIN}/auth`,
@@ -12,6 +12,7 @@ export const paths = {
   minimalUI: 'https://mui.com/store/items/minimal-dashboard/',
   // AUTH
   auth: {
+    root: `${ROOTS.AUTH}`,
     jwt: {
       login: `${ROOTS.AUTH}/jwt/login`,
       register: `${ROOTS.AUTH}/jwt/register`,
@@ -19,7 +20,7 @@ export const paths = {
   },
   // DASHBOARD
   dashboard: {
-    root: ROOTS.DASHBOARD,
+    root: `${ROOTS.DASHBOARD}`,
     one: `${ROOTS.DASHBOARD}/one`,
     two: `${ROOTS.DASHBOARD}/two`,
     three: `${ROOTS.DASHBOARD}/three`,

--- a/src/routes/sections/auth.tsx
+++ b/src/routes/sections/auth.tsx
@@ -6,6 +6,7 @@ import { Outlet } from 'react-router-dom';
 import AuthClassicLayout from 'src/layouts/auth/classic';
 // components
 import { SplashScreen } from 'src/components/loading-screen';
+import { DOMAIN, paths } from '../paths';
 
 // ----------------------------------------------------------------------
 
@@ -44,7 +45,7 @@ const authJwt = {
 
 export const authRoutes = [
   {
-    path: 'auth',
+    path: `${paths.auth.root}`,
     children: [authJwt],
   },
 ];

--- a/src/routes/sections/dashboard.tsx
+++ b/src/routes/sections/dashboard.tsx
@@ -6,6 +6,7 @@ import { Outlet } from 'react-router-dom';
 import DashboardLayout from 'src/layouts/dashboard';
 // components
 import { LoadingScreen } from 'src/components/loading-screen';
+import { DOMAIN, paths } from '../paths';
 
 // ----------------------------------------------------------------------
 
@@ -20,7 +21,7 @@ const PageSix = lazy(() => import('src/pages/dashboard/six'));
 
 export const dashboardRoutes = [
   {
-    path: 'dashboard',
+    path: `${paths.dashboard.root}`,
     element: (
       <DashboardLayout>
         <Suspense fallback={<LoadingScreen />}>

--- a/src/routes/sections/index.tsx
+++ b/src/routes/sections/index.tsx
@@ -2,6 +2,7 @@ import { Navigate, useRoutes } from 'react-router-dom';
 // config
 import { PATH_AFTER_LOGIN } from 'src/config-global';
 //
+
 import { mainRoutes } from './main';
 
 import { authRoutes } from './auth';
@@ -12,7 +13,7 @@ import { dashboardRoutes } from './dashboard';
 export default function Router() {
   return useRoutes([
     {
-      path: '/',
+      path: `/`,
       element: <Navigate to={PATH_AFTER_LOGIN} replace />,
     },
 

--- a/src/sections/auth/jwt/jwt-login-view.tsx
+++ b/src/sections/auth/jwt/jwt-login-view.tsx
@@ -22,6 +22,7 @@ import { useSetRecoilState } from 'recoil';
 import { userState } from 'src/utils/atom';
 import { Link } from 'react-router-dom';
 import { useSnackbar } from 'notistack';
+import { paths } from 'src/routes/paths';
 
 // ----------------------------------------------------------------------
 
@@ -77,7 +78,7 @@ export default function JwtLoginView() {
 
       // await login?.(data.email, data.password);
 
-      router.push('/dashboard');
+      router.push(`${paths.dashboard.root}`);
     } catch (error) {
       enqueueSnackbar('로그인 정보가 틀렸습니다', {
         variant: 'error',


### PR DESCRIPTION
## 요약

### 1) 페이지 라우팅 설정
와랩 서버 walab.handong.edu/sw_mileage의 uri로 접근이 가능하도록 배포를 요청 받았기 때문에 환경 변수와 라우팅 설정을 sw_mileage 위에서 돌아가도록 설정.

REACT_APP_HOST_BASE_DOMAIN=/sw_mileage 추가 필요
모든 라우팅 위에 REACT_APP_HOST_BASE_DOMAIN가 들어 가야 함.

### 2) 소스 번들 라우팅 설정

`<link rel="manifest" href="%PUBLIC_URL%/manifest.json" />`
와 같은 여러 css , js 파일에 sw_mileage 경로를 추가해야함
public_url을 추가 시키고 이를 환경 변수에서 관리

